### PR TITLE
docs: Add documentation page to charmhub

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,7 +11,11 @@ description: |
 summary: |
   ACME operator implementing the provider side of the `tls-certificates`
   interface to get signed certificates from the `Let's Encrypt` ACME server using route53 DNS.
-website: https://github.com/canonical/route53-acme-operator
+website: https://charmhub.io/route53-acme-operator
+source: https://github.com/canonical/route53-acme-operator
+issues: https://github.com/canonical/route53-acme-operator/issues
+docs: https://discourse.charmhub.io/t/route53-acme-operator-docs-index/12514
+
 
 provides:
   certificates:


### PR DESCRIPTION
# Description

Improve metadata.yaml and set documentation point to the corresponding discourse topic : https://discourse.charmhub.io/t/route53-acme-operator-docs-index/12514

Documentation has a reference to the [TLS certificates topic](https://charmhub.io/topics/secure-your-charm-deployments-with-x-509-certificates)

My charmhub post has been hidden. Need to fix this.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
